### PR TITLE
Netflix provider for jellyroll

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,7 @@ Optional
 * GitPython (for Git support)
 * pysvn (for SVN support)
 * feedparser (for YouTube support)
+* oauth2 (for Netflix support)
 
 Installation
 ------------

--- a/src/jellyroll/admin.py
+++ b/src/jellyroll/admin.py
@@ -2,6 +2,7 @@ import django.forms
 from django.contrib import admin
 from jellyroll.models import Item, Bookmark, Track, Photo, WebSearch, Message
 from jellyroll.models import WebSearchResult, Video, CodeRepository, CodeCommit
+from jellyroll.models import Purchase
 
 class ItemAdmin(admin.ModelAdmin):
     date_hierarchy = 'timestamp'
@@ -55,6 +56,10 @@ class CodeCommitAdmin(admin.ModelAdmin):
     list_filter = ('repository',)
     search_fields = ('message',)
 
+class PurchaseAdmin(admin.ModelAdmin):
+    list_display = ('title', 'url')
+    search_fields = ('title', 'description')
+
 admin.site.register(Item, ItemAdmin)
 admin.site.register(Bookmark, BookmarkAdmin)
 admin.site.register(Track, TrackAdmin)
@@ -64,4 +69,4 @@ admin.site.register(Message, MessageAdmin)
 admin.site.register(Video, VideoAdmin)
 admin.site.register(CodeRepository, CodeRepositoryAdmin)
 admin.site.register(CodeCommit, CodeCommitAdmin)
-
+admin.site.register(Purchase, PurchaseAdmin)

--- a/src/jellyroll/fixtures/purchases.json
+++ b/src/jellyroll/fixtures/purchases.json
@@ -1,0 +1,24 @@
+[
+    {
+        "pk": 1, 
+        "model": "jellyroll.purchase", 
+        "fields": {
+            "url": "http://www.netflix.com/Movie/Manufactured_Landscapes/70059641", 
+            "rating": "", 
+            "image_url": "http://cdn-1.nflximg.com/us/boxshots/tiny/70059641.jpg", 
+            "description": "", 
+            "title": "Manufactured Landscapes"
+        }
+    }, 
+    {
+        "pk": 2, 
+        "model": "jellyroll.purchase", 
+        "fields": {
+            "url": "http://www.netflix.com/Movie/The_Passenger/70042799", 
+            "rating": "", 
+            "image_url": "http://cdn-9.nflximg.com/us/boxshots/tiny/70042799.jpg", 
+            "description": "", 
+            "title": "The Passenger"
+        }
+    }
+]

--- a/src/jellyroll/management/commands/jellyroll_netflix_tokens.py
+++ b/src/jellyroll/management/commands/jellyroll_netflix_tokens.py
@@ -1,0 +1,64 @@
+import logging
+import optparse
+import urllib
+import oauth2 as oauth
+import cgi # parse_qsl is in urlparse in Python2.6
+
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
+REQUEST_TOKEN_URL = 'http://api.netflix.com/oauth/request_token'
+ACCESS_TOKEN_URL = 'http://api.netflix.com/oauth/access_token'
+AUTHORIZE_URL = 'https://api-user.netflix.com/oauth/login'
+NETFLIX_APP_NAME = 'jellyroll-netflix-provider'
+
+class Command(BaseCommand):
+    
+    def handle(self, *args, **options):
+        self.get_request_token()
+
+    def get_request_token(self):
+        # Adapted from example usage at https://github.com/simplegeo/python-oauth2
+        consumer = oauth.Consumer(settings.NETFLIX_CONSUMER_KEY, settings.NETFLIX_CONSUMER_SECRET)
+        client = oauth.Client(consumer)
+        resp, content = client.request(REQUEST_TOKEN_URL, "GET")
+        request_token = dict(cgi.parse_qsl(content))
+
+        authorize_url_dict = {
+            'oauth_token': request_token['oauth_token'],
+            'oauth_consumer_key': settings.NETFLIX_CONSUMER_KEY,
+            'application_name': NETFLIX_APP_NAME
+        }
+        # oauth_callback unnecessary in this case
+
+        print "Request Token:"
+        print "    - oauth_token        = %s" % request_token['oauth_token']
+        print "    - oauth_token_secret = %s" % request_token['oauth_token_secret']
+
+        print "Go to the following link in your browser:"
+        print "%s?%s" % (AUTHORIZE_URL, urllib.urlencode(authorize_url_dict))
+        print
+
+        accepted = 'n'
+        while accepted.lower() == 'n':
+            accepted = raw_input('Have you authorized me? (y/n) ')
+    
+        self.get_access_token(consumer, request_token)
+    
+    def get_access_token(self, consumer, request_token):
+        token = oauth.Token(request_token['oauth_token'],
+            request_token['oauth_token_secret'])
+        # token.set_verifier(oauth_verifier)
+        client = oauth.Client(consumer, token)
+
+        resp, content = client.request(ACCESS_TOKEN_URL, "POST")
+        access_token = dict(cgi.parse_qsl(content))    
+
+        print "Access Token:"
+        print "    - oauth_token        = %s" % access_token['oauth_token']
+        print "    - oauth_token_secret = %s" % access_token['oauth_token_secret']
+        print
+        print "You may now access protected resources using the access tokens above."     
+        print "Assign the oauth_token value to NETFLIX_OAUTH_TOKEN and oauth_token_secret"
+        print "to NETFLIX_OAUTH_TOKEN_SECRET in your application's settings.py"
+

--- a/src/jellyroll/management/commands/jellyroll_netflix_tokens.py
+++ b/src/jellyroll/management/commands/jellyroll_netflix_tokens.py
@@ -3,6 +3,7 @@ import optparse
 import urllib
 import oauth2 as oauth
 import cgi # parse_qsl is in urlparse in Python2.6
+import sys
 
 from django.core.management.base import BaseCommand
 from django.conf import settings
@@ -10,7 +11,6 @@ from django.conf import settings
 REQUEST_TOKEN_URL = 'http://api.netflix.com/oauth/request_token'
 ACCESS_TOKEN_URL = 'http://api.netflix.com/oauth/access_token'
 AUTHORIZE_URL = 'https://api-user.netflix.com/oauth/login'
-NETFLIX_APP_NAME = 'jellyroll-netflix-provider'
 
 class Command(BaseCommand):
     
@@ -18,16 +18,19 @@ class Command(BaseCommand):
         self.get_request_token()
 
     def get_request_token(self):
-        # Adapted from example usage at https://github.com/simplegeo/python-oauth2
+        # Adapted from example usage docs at https://github.com/simplegeo/python-oauth2
         consumer = oauth.Consumer(settings.NETFLIX_CONSUMER_KEY, settings.NETFLIX_CONSUMER_SECRET)
         client = oauth.Client(consumer)
         resp, content = client.request(REQUEST_TOKEN_URL, "GET")
+        if resp['status'] != '200':
+            print 'Error:', resp['status'], content
+            sys.exit()
         request_token = dict(cgi.parse_qsl(content))
 
         authorize_url_dict = {
             'oauth_token': request_token['oauth_token'],
             'oauth_consumer_key': settings.NETFLIX_CONSUMER_KEY,
-            'application_name': NETFLIX_APP_NAME
+            'application_name': settings.NETFLIX_APP_NAME # TODO: is this really required?
         }
         # oauth_callback unnecessary in this case
 

--- a/src/jellyroll/models.py
+++ b/src/jellyroll/models.py
@@ -375,7 +375,20 @@ class Location(models.Model):
     @property
     def url(self):
         return "http://maps.google.com/maps?q=%s,%s" % (self.longitude, self.latitude)
-        
+
+class Purchase(models.Model):
+    """
+    A purchase (eg. from Amazon.com) or a rental (eg. Netflix)
+    """
+    title = models.CharField(max_length=255)
+    description = models.CharField(max_length=1000)
+    url = models.URLField()
+    image_url = models.URLField()
+    rating = models.CharField(max_length=10)
+    
+    def __unicode__(self):
+        return self.title
+
 # Register item objects to be "followed"
 Item.objects.follow_model(Bookmark)
 Item.objects.follow_model(Track)
@@ -385,3 +398,4 @@ Item.objects.follow_model(Video)
 Item.objects.follow_model(CodeCommit)
 Item.objects.follow_model(Message)
 Item.objects.follow_model(Location)
+Item.objects.follow_model(Purchase)

--- a/src/jellyroll/providers/delicious.py
+++ b/src/jellyroll/providers/delicious.py
@@ -74,7 +74,7 @@ def update():
 
 def _update_bookmarks_from_date(delicious, dt):
     log.debug("Reading bookmarks from %s", dt)
-    xml = delicious.posts.get(dt=dt.strftime("%Y-%m-%d"))
+    xml = delicious.posts.get(dt=dt.strftime("%Y-%m-%d") + "T00:00:00Z")
     for post in xml.getiterator('post'):
         info = dict((k, smart_unicode(post.get(k))) for k in post.keys())
         if (info.has_key("shared") and settings.DELICIOUS_GETDNS) or (not info.has_key("shared")):

--- a/src/jellyroll/providers/netflix.py
+++ b/src/jellyroll/providers/netflix.py
@@ -1,0 +1,175 @@
+"""
+Provider for Netflix user history. Currently gets recently returned DVDs.
+
+Currently requires creation of Netflix API tokens for settings.py 
+using ``./manage.py jellyroll_netflix_tokens``. Set ``NETFLIX_CONSUMER_KEY``
+and ``NETFLIX_CONSUMER_SECRET`` from your Netflix API account and then run.
+
+Required settings.py values:
+
+    * ``NETFLIX_CONSUMER_KEY``
+    * ``NETFLIX_CONSUMER_SECRET``
+    * ``NETFLIX_OAUTH_TOKEN``
+    * ``NETFLIX_OAUTH_TOKEN_SECRET``
+
+Optional settings.py values:
+
+    * ``NETFLIX_TAG_ALL``: a string that all items will be tagged with (eg. "film")
+    * ``NETFLIX_TAGS_FROM_CATEGORIES`` -- boolean indicating whether to create tags
+      from Netflix categories
+    * ``NETFLIX_TAG_PROCESSOR``: a function that takes a list of Netflix categories
+      (e.g. ``["Foreign Art-House Thrillers", "German Language"]``) and returns a list
+      of tags created by your function's custom logic.
+"""
+from datetime import datetime
+import hashlib
+import logging
+import time 
+import urlparse, urllib
+import oauth2 as oauth
+import time
+
+from django.conf import settings
+from django.db import transaction
+from django.utils.encoding import smart_str, smart_unicode
+
+from jellyroll.models import Purchase, Item
+from jellyroll.providers import utils
+
+log = logging.getLogger("jellyroll.providers.netflix")
+
+class NetflixClient(object):
+    '''
+    A mini Netflix API client
+    '''
+    updated_min = None
+    
+    def __init__(self, oauth_token, oauth_token_secret, updated_min, method='users'):
+        self.method = method
+        if self.method == 'users':
+            self.method = 'users/%s' % oauth_token
+        self.oauth_token = oauth_token
+        self.oauth_token_secret = oauth_token_secret
+        self.updated_min = updated_min
+       
+    def __getattr__(self, method):
+        return NetflixClient(self.oauth_token, self.oauth_token_secret, self.updated_min, '%s/%s' % (self.method, method))
+       
+    def __call__(self, **params):
+        url = 'http://api.netflix.com/%s' % self.method
+        return self._make_request(url)
+    
+    def _make_request(self, api_endpoint):
+        params = {
+            'oauth_token': self.oauth_token,
+            'oauth_consumer_key': settings.NETFLIX_CONSUMER_KEY,
+            'oauth_nonce': oauth.generate_nonce(),
+            'oauth_timestamp': int(time.time()),
+            'output': 'json',
+            'max_results': '10' # up to 100 legally, but will give back more (200?)
+        }
+        if self.updated_min:
+            params['updated_min'] = self.updated_min
+        consumer = oauth.Consumer(settings.NETFLIX_CONSUMER_KEY, settings.NETFLIX_CONSUMER_SECRET)
+        token = oauth.Token(key=self.oauth_token, secret=self.oauth_token_secret)
+        req = oauth.Request(method="GET", url=api_endpoint, parameters=params)
+        signature_method = oauth.SignatureMethod_HMAC_SHA1()
+        req.sign_request(signature_method, consumer, token)
+
+        url = req.to_url()
+        return utils.getjson(url)
+
+#
+# Public API
+#
+def enabled():
+    ok = (hasattr(settings, "NETFLIX_CONSUMER_KEY") and
+          hasattr(settings, "NETFLIX_CONSUMER_SECRET"))
+    if not ok:
+      log.warn('The Netflix provider is not available because the '
+               'NETFLIX_CONSUMER_KEY, and/or NETFLIX_CONSUMER_SECRET settings '
+               'are undefined.')
+    return ok
+
+def update():
+    # FIXME: below values should both be stored in/retrieved from DB
+    oauth_token = settings.NETFLIX_OAUTH_TOKEN
+    oauth_token_secret = settings.NETFLIX_OAUTH_TOKEN_SECRET
+
+    last_update_date = Item.objects.get_last_update_of_model(Purchase, source=__name__)
+    if last_update_date:
+        last_update_epoch = int(time.mktime(last_update_date.timetuple())) + 1
+        updated_min = last_update_epoch
+    else:
+        updated_min = None
+
+    netflix = NetflixClient(oauth_token, oauth_token_secret, updated_min)
+    results = netflix.rental_history.returned()
+    
+    if results['rental_history'].has_key('rental_history_item'):
+        log.info('Processing %s results.' % results['rental_history']['number_of_results'])
+        if isinstance(results['rental_history']['rental_history_item'], dict):
+            items = [results['rental_history']['rental_history_item']]
+        else:
+            items = results['rental_history']['rental_history_item']
+        for i in items:
+            tags = []
+            title = i['title']['regular']
+            image_url = i['box_art']['small']
+            for link in i['link']:
+                if link['title'] == 'web page':
+                    link = link['href']
+            if hasattr(settings, "NETFLIX_TAGS_FROM_CATEGORIES"):
+                categories = []
+                if settings.NETFLIX_TAGS_FROM_CATEGORIES:
+                    for j in i['category']:
+                        if j['scheme'] == 'http://api.netflix.com/categories/genres':
+                            categories.append(j['term'])
+                    if hasattr(settings, "NETFLIX_TAG_PROCESSOR"):
+                        # TODO: error handling if not a function
+                        process_tags = settings.NETFLIX_TAG_PROCESSOR
+                        tags = tags + process_tags(categories)
+                    else:
+                        tags = tags + _categories_to_tags(categories)
+                        
+            timestamp = datetime.fromtimestamp(float(i['returned_date'])) # TODO: use utils.parsedate?
+            tags = list(set(tags))
+            if hasattr(settings, 'NETFLIX_TAG_ALL'):
+                if settings.NETFLIX_TAG_ALL:
+                    tags.append(settings.NETFLIX_TAG_ALL)
+            _handle_rental(title, link, image_url, tags, timestamp)
+    else:
+        log.info("No new items. Skipping.")
+
+#
+# Private API
+#
+
+@transaction.commit_on_success
+def _handle_rental(title, link, image_url, tags, timestamp):
+    tags = " ".join(tags)
+    i, created = Purchase.objects.get_or_create(
+        title = title,
+        # description = None, # TODO
+        url = link,
+        image_url = image_url,
+    )
+    # if not created:
+    
+    return Item.objects.create_or_update(
+        instance = i, 
+        timestamp = timestamp, 
+        tags = tags,
+        source = __name__,
+        source_id = _source_id(title, timestamp),
+    )
+
+def _categories_to_tags(categories):
+    tags = []
+    for i in categories:
+        tags.append(i.replace(' & ', ' ').replace(' ', '-').lower())
+    return tags
+
+def _source_id(title, timestamp):
+    return hashlib.md5(smart_str(title) + str(timestamp)).hexdigest()
+

--- a/src/jellyroll/tests/__init__.py
+++ b/src/jellyroll/tests/__init__.py
@@ -5,3 +5,4 @@ from jellyroll.tests.test_misc import *
 from jellyroll.tests.providers.test_delicious import *
 from jellyroll.tests.providers.test_flickr import *
 from jellyroll.tests.providers.test_latitude import *
+from jellyroll.tests.providers.test_netflix import *

--- a/src/jellyroll/tests/providers/test_netflix.py
+++ b/src/jellyroll/tests/providers/test_netflix.py
@@ -1,0 +1,255 @@
+from __future__ import with_statement
+
+import mock
+import datetime
+import unittest
+from django.conf import settings
+from django.test import TestCase
+from jellyroll.models import Item, Purchase
+from jellyroll.providers import netflix, utils
+
+class NetflixClientTests(unittest.TestCase):
+    
+    def test_client_getattr(self):
+        c = netflix.NetflixClient('aaaa', 'bbbb', None)
+        self.assertEqual(c.oauth_token, 'aaaa')
+        self.assertEqual(c.oauth_token_secret, 'bbbb')
+        self.assertEqual(c.updated_min, None)
+        
+        c2 = c.foo.bar.baz
+        self.assertEqual(c2.oauth_token, 'aaaa')
+        self.assertEqual(c2.oauth_token_secret, 'bbbb')
+        self.assertEqual(c2.method, 'users/%s/foo/bar/baz' % c.oauth_token)
+        
+    def test_client_call(self):
+        mock_getjson = mock.Mock(return_value={})
+        with mock.patch_object(utils, 'getjson', mock_getjson) as mocked:
+            c = netflix.NetflixClient('aaaa', 'bbbb', None)
+            res = c.foo.bar(a=1, b=2)
+            self.assert_(mocked.called)
+
+#
+# Mock Netflix client
+#
+
+FakeClient = mock.Mock()
+FakeClient.return_value = FakeClient
+
+FakeClient.rental_history.returned.return_value = {
+    'rental_history': {
+        'url_template': 'http://api.netflix.com/users/aaaa-/rental_history/returned?{-join|&|start_index|max_results}',
+        'rental_history_item': [{
+            'category': [{
+                'term': 'Returned',
+                'scheme': 'http://api.netflix.com/categories/rental_states',
+                'label': 'Returned'
+            },
+            {
+                'term': 'NR',
+                'scheme': 'http://api.netflix.com/categories/mpaa_ratings',
+                'label': 'NR'
+            },
+            {
+                'term': 'Documentary',
+                'scheme': 'http://api.netflix.com/categories/genres',
+                'label': 'Documentary'
+            },
+            {
+                'term': 'Social & Cultural Documentaries',
+                'scheme': 'http://api.netflix.com/categories/genres',
+                'label': 'Social & Cultural Documentaries'
+            },
+            {
+                'term': 'Photography',
+                'scheme': 'http://api.netflix.com/categories/genres',
+                'label': 'Photography'
+            },
+            {
+                'term': 'Art & Design',
+                'scheme': 'http://api.netflix.com/categories/genres',
+                'label': 'Art & Design'
+            }],
+            'box_art': {
+                'large': 'http://cdn-1.nflximg.com/us/boxshots/large/70059641.jpg',
+                'small': 'http://cdn-1.nflximg.com/us/boxshots/tiny/70059641.jpg',
+                'medium': 'http://cdn-1.nflximg.com/us/boxshots/small/70059641.jpg'
+            },
+            'release_year': '2007',
+            'title': {
+                'regular': 'Manufactured Landscapes',
+                'short': 'Manufactured Landscapes'
+            },
+            'updated': '1288583594',
+            'average_rating': '3.6',
+            'link': [{
+                'href': 'http://api.netflix.com/catalog/titles/movies/70059641',
+                'rel': 'http://schemas.netflix.com/catalog/title',
+                'title': 'Manufactured Landscapes'
+            },
+            {
+                'href': 'http://api.netflix.com/catalog/titles/movies/70059641/synopsis',
+                'rel': 'http://schemas.netflix.com/catalog/titles/synopsis',
+                'title': 'synopsis'
+            },
+            {
+                'href': 'http://api.netflix.com/catalog/titles/movies/70059641/cast',
+                'rel': 'http://schemas.netflix.com/catalog/people.cast',
+                'title': 'cast'
+            },
+            {
+                'href': 'http://api.netflix.com/catalog/titles/movies/70059641/directors',
+                'rel': 'http://schemas.netflix.com/catalog/people.directors',
+                'title': 'directors'
+            },
+            {
+                'href': 'http://api.netflix.com/catalog/titles/movies/70059641/format_availability',
+                'rel': 'http://schemas.netflix.com/catalog/titles/format_availability',
+                'title': 'formats'
+            },
+            {
+                'href': 'http://api.netflix.com/catalog/titles/movies/70059641/screen_formats',
+                'rel': 'http://schemas.netflix.com/catalog/titles/screen_formats',
+                'title': 'screen formats'
+            },
+            {
+                'href': 'http://api.netflix.com/catalog/titles/movies/70059641/languages_and_audio',
+                'rel': 'http://schemas.netflix.com/catalog/titles/languages_and_audio',
+                'title': 'languages and audio'
+            },
+            {
+                'href': 'http://api.netflix.com/catalog/titles/movies/70059641/similars',
+                'rel': 'http://schemas.netflix.com/catalog/titles.similars',
+                'title': 'similars'
+            },
+            {
+                'href': 'http://www.netflix.com/Movie/Manufactured_Landscapes/70059641',
+                'rel': 'alternate',
+                'title': 'web page'
+            }],
+            'returned_date': '1288583594',
+            'runtime': '5400',
+            'id': 'http://api.netflix.com/users/aaaa-/rental_history/returned/70059641'
+        },
+        {
+            'category': [{
+                'term': 'Returned',
+                'scheme': 'http://api.netflix.com/categories/rental_states',
+                'label': 'Returned'
+            },
+            {
+                'term': 'PG',
+                'scheme': 'http://api.netflix.com/categories/mpaa_ratings',
+                'label': 'PG'
+            },
+            {
+                'term': 'Classics',
+                'scheme': 'http://api.netflix.com/categories/genres',
+                'label': 'Classics'
+            },
+            {
+                'term': 'Classic Thrillers',
+                'scheme': 'http://api.netflix.com/categories/genres',
+                'label': 'Classic Thrillers'
+            },
+            {
+                'term': 'Espionage Thrillers',
+                'scheme': 'http://api.netflix.com/categories/genres',
+                'label': 'Espionage Thrillers'
+            },
+            {
+                'term': 'Psychological Thrillers',
+                'scheme': 'http://api.netflix.com/categories/genres',
+                'label': 'Psychological Thrillers'
+            }],
+            'box_art': {
+                'large': 'http://cdn-9.nflximg.com/us/boxshots/large/70042799.jpg',
+                'small': 'http://cdn-9.nflximg.com/us/boxshots/tiny/70042799.jpg',
+                'medium': 'http://cdn-9.nflximg.com/us/boxshots/small/70042799.jpg'
+            },
+            'release_year': '1975',
+            'title': {
+                'regular': 'The Passenger',
+                'short': 'The Passenger'
+            },
+            'updated': '1287108821',
+            'average_rating': '3.2',
+            'link': [{
+                'href': 'http://api.netflix.com/catalog/titles/movies/70042799',
+                'rel': 'http://schemas.netflix.com/catalog/title',
+                'title': 'The Passenger'
+            },
+            {
+                'href': 'http://api.netflix.com/catalog/titles/movies/70042799/synopsis',
+                'rel': 'http://schemas.netflix.com/catalog/titles/synopsis',
+                'title': 'synopsis'
+            },
+            {
+                'href': 'http://api.netflix.com/catalog/titles/movies/70042799/cast',
+                'rel': 'http://schemas.netflix.com/catalog/people.cast',
+                'title': 'cast'
+            },
+            {
+                'href': 'http://api.netflix.com/catalog/titles/movies/70042799/directors',
+                'rel': 'http://schemas.netflix.com/catalog/people.directors',
+                'title': 'directors'
+            },
+            {
+                'href': 'http://api.netflix.com/catalog/titles/movies/70042799/format_availability',
+                'rel': 'http://schemas.netflix.com/catalog/titles/format_availability',
+                'title': 'formats'
+            },
+            {
+                'href': 'http://api.netflix.com/catalog/titles/movies/70042799/screen_formats',
+                'rel': 'http://schemas.netflix.com/catalog/titles/screen_formats',
+                'title': 'screen formats'
+            },
+            {
+                'href': 'http://api.netflix.com/catalog/titles/movies/70042799/languages_and_audio',
+                'rel': 'http://schemas.netflix.com/catalog/titles/languages_and_audio',
+                'title': 'languages and audio'
+            },
+            {
+                'href': 'http://api.netflix.com/catalog/titles/movies/70042799/similars',
+                'rel': 'http://schemas.netflix.com/catalog/titles.similars',
+                'title': 'similars'
+            },
+            {
+                'href': 'http://www.sonyclassics.com/thepassenger/index_content.html',
+                'rel': 'http://schemas.netflix.com/catalog/titles/official_url',
+                'title': 'official webpage'
+            },
+            {
+                'href': 'http://www.netflix.com/Movie/The_Passenger/70042799',
+                'rel': 'alternate',
+                'title': 'web page'
+            }],
+            'returned_date': '1287108821',
+            'runtime': '7560',
+            'id': 'http://api.netflix.com/users/aaaa-/rental_history/returned/70042799'
+        }],
+        'results_per_page': '10',
+        'start_index': '0',
+        'number_of_results': '2'
+    }
+}
+
+class NetflixProviderTests(TestCase):
+    
+    def test_enabled(self):
+        self.assertEqual(netflix.enabled(), True)
+        
+    @mock.patch_object(netflix, 'NetflixClient', FakeClient)
+    def test_update(self):
+        netflix.update()
+    
+        FakeClient.assert_called_with(settings.NETFLIX_OAUTH_TOKEN, settings.NETFLIX_OAUTH_TOKEN_SECRET, 1)
+        FakeClient.rental_history.returned.assert_called_with()
+        
+        # Check that the returned rental exists
+        p = Purchase.objects.get(url="http://www.netflix.com/Movie/The_Passenger/70042799")
+        self.assertEqual(p.title, "The Passenger")
+        # Check that the Item exists
+        i = Item.objects.get(content_type__model='purchase', object_id=p.pk)
+        self.assertEqual(i.timestamp.date(), datetime.date(2010, 10, 14))
+    
+

--- a/src/jellyroll/tests/test_items.py
+++ b/src/jellyroll/tests/test_items.py
@@ -108,9 +108,25 @@ class VideoTest(TestCase):
     def testYouTube(self):
         v = Video.objects.get(pk=2)
         self.assertEqual(v.embed_url, "http://www.youtube.com/v/1gvGDsIYrrQ")
+
+class PurchaseTest(TestCase):
+    fixtures = ["purchases.json"]
         
+    def testItemWorkage(self):
+        i = Item.objects.get(content_type=CT(Purchase), object_id="1")
+        self.assertEqual(i.url, i.object.url)
+        self.assertEqual(i.object_str, str(i.object))
+
 class ItemTest(TestCase):
-    fixtures = ["bookmarks.json", "photos.json", "trac.json", "tracks.json", "videos.json", "websearches.json"]
+    fixtures = [
+        "bookmarks.json", 
+        "photos.json", 
+        "trac.json", 
+        "tracks.json", 
+        "videos.json", 
+        "websearches.json", 
+        "purchases.json"
+    ]
     
     def testSorting(self):
         items = list(Item.objects.all())
@@ -123,4 +139,4 @@ class ItemTest(TestCase):
         self.assertEqual(Item.objects.models_by_name["track"], Track)
         self.assertEqual(Item.objects.models_by_name["video"], Video)
         self.assertEqual(Item.objects.models_by_name["websearch"], WebSearch)
-        
+        self.assertEqual(Item.objects.models_by_name["purchase"], Purchase)

--- a/src/jellyroll/tests/test_misc.py
+++ b/src/jellyroll/tests/test_misc.py
@@ -14,6 +14,7 @@ class MiscTests(unittest.TestCase):
             'jellyroll.providers.svn',
             'jellyroll.providers.twitter',
             'jellyroll.providers.youtube',
+            'jellyroll.providers.netflix',            
         ]
         expanded.sort()
         expected.sort()

--- a/src/jellyroll/testsettings.py
+++ b/src/jellyroll/testsettings.py
@@ -12,7 +12,10 @@ JELLYROLL_PROVIDERS = ['jellyroll.providers.*']
 # the APIs anyway.
 DELICIOUS_USERNAME = FLICKR_USERNAME = GOOGLE_USERNAME = LASTFM_USERNAME \
                    = TWITTER_USERNAME = YOUTUBE_USERNAME \
-                   = GOOGLE_LATITUDE_USER_ID = 'jellyroll'
+                   = GOOGLE_LATITUDE_USER_ID \
+                   = NETFLIX_CONSUMER_KEY = NETFLIX_CONSUMER_SECRET \
+                   = NETFLIX_OAUTH_TOKEN = NETFLIX_OAUTH_TOKEN_SECRET \
+                   =  'jellyroll'
 DELICIOUS_PASSWORD = GOOGLE_PASSWORD = 'password'
 FLICKR_API_KEY = 'apikey'
 FLICKR_USER_ID = 'userid'


### PR DESCRIPTION
Jacob,

I've added a Netflix provider (with tests) for Jellyroll, making use of their OAuth-enabled RESTful API.  The only new requirement is the oauth2 library, which I've indicated as an optional dependency in the README.  As you'll note from the documentation in the new provider module, there's a new management command as well to generate the necessary oAuth tokens to put into your settings file.

Currently, it shows only recently returned DVDs -- this suits my purposes currently, but if there's interest, I could make this configurable to get other kinds of data.  Users will need a Netflix developer account and API key to use it.

It makes use of a new "Purchase" model in models.py -- even though Netflix DVDs are "rentals", I envisioned this as a generic model to support other things in the future such as Amazon.com wishlists or purchases.

Let me know if you're interested in adding this feature.

Thanks -- and thanks for jellyroll (and Django for that matter :),

Matt
